### PR TITLE
Make sure ap_hook_post_read_request always runs first

### DIFF
--- a/mod_ruid2.c
+++ b/mod_ruid2.c
@@ -679,7 +679,7 @@ static void register_hooks (apr_pool_t *p)
 
 	ap_hook_post_config (ruid_init, NULL, NULL, APR_HOOK_MIDDLE);
 	ap_hook_child_init (ruid_child_init, NULL, NULL, APR_HOOK_MIDDLE);
-	ap_hook_post_read_request(ruid_setup, NULL, NULL, APR_HOOK_MIDDLE);
+	ap_hook_post_read_request(ruid_setup, NULL, NULL, APR_HOOK_REALLY_FIRST);
 	ap_hook_header_parser(ruid_uiiii, NULL, NULL, APR_HOOK_FIRST);
 }
 


### PR DESCRIPTION
This solves an issue we've had with mod_security where Apache hadn't changed to the right user when mod_security ran. This resulted in some unwanted behaviour where it partially ran as www-data and partially as the user set up in mod_ruid2. 
